### PR TITLE
add notifier component, fix bug with negative time

### DIFF
--- a/src/lib/components/Notifier.svelte
+++ b/src/lib/components/Notifier.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+    import { onMount, tick } from "svelte";
+
+    let showNotice = false
+    let permissionGranted = false
+
+    async function requestPermission() {
+        showNotice = true
+        await tick() // show the notice before we requrest the permission
+        const permission = await Notification.requestPermission()
+        showNotice = false
+        return permission
+    }
+    
+    onMount(async () => {
+        if (!('Notification' in window)) {
+            console.log("This browser does not support the Notification API")
+        } else {
+            try {
+                if (Notification.permission === 'default') {
+                    permissionGranted = await requestPermission() === 'granted' ? true : false
+                } else if (Notification.permission === 'granted') {
+                    await Notification.requestPermission() // let the browser know we'll use it
+                    permissionGranted = true
+                }
+                console.log(permissionGranted)
+            } catch (e) {
+                showNotice = false
+                console.log("This browser does not support the promisified Notification API")
+            }
+        }
+    })
+
+    
+</script>
+
+<script context="module" lang="ts">
+    export function timerEndNotification(timerLength: string) {
+        new Notification('niagara', {
+            body: `Time's up! Your timer for ${timerLength} has gone off.`,
+            icon: '/favicon.png'
+        })
+    }
+</script>
+
+<style>
+	/* your styles go here */
+</style>
+
+{#if showNotice}
+    <div class="p-8 bg-neutral-700/30 rounded-lg my-4">
+        If you enable the Notification Permission, <br>you will get a notification once the timer goes off.
+    </div>
+{/if}

--- a/src/lib/components/Notifier.svelte
+++ b/src/lib/components/Notifier.svelte
@@ -1,37 +1,40 @@
 <script lang="ts">
-    import { onMount, tick } from "svelte";
+    import { onMount } from "svelte";
 
     let showNotice = false
     let permissionGranted = false
+    let notificationSupported = true
 
-    async function requestPermission() {
-        showNotice = true
-        await tick() // show the notice before we requrest the permission
-        const permission = await Notification.requestPermission()
-        showNotice = false
-        return permission
-    }
-    
-    onMount(async () => {
-        if (!('Notification' in window)) {
-            console.log("This browser does not support the Notification API")
-        } else {
+    async function triggerPermissionRequest() {
+        if (notificationSupported) {
             try {
                 if (Notification.permission === 'default') {
-                    permissionGranted = await requestPermission() === 'granted' ? true : false
-                } else if (Notification.permission === 'granted') {
-                    await Notification.requestPermission() // let the browser know we'll use it
-                    permissionGranted = true
+                    permissionGranted = await Notification.requestPermission() === 'granted' ? true : false
+                    showNotice = false
                 }
                 console.log(permissionGranted)
             } catch (e) {
                 showNotice = false
                 console.log("This browser does not support the promisified Notification API")
+                notificationSupported = false
+            }
+        }
+    }
+    
+    onMount(async () => {
+        if (!('Notification' in window)) {
+            console.log("This browser does not support the Notification API")
+            notificationSupported = false
+        } else {
+            if (Notification.permission === 'default') { 
+                showNotice = true 
+            } else if (Notification.permission === 'granted') {
+                await Notification.requestPermission() // let the browser know we'll use it
+                permissionGranted = true
             }
         }
     })
 
-    
 </script>
 
 <script context="module" lang="ts">
@@ -48,7 +51,8 @@
 </style>
 
 {#if showNotice}
-    <div class="p-8 bg-neutral-700/30 rounded-lg my-4">
-        If you enable the Notification Permission, <br>you will get a notification once the timer goes off.
+    <div class="flex gap-3 align-middle justify-center">
+        <span>Enable notifications once timer goes off?</span>
+        <button class="bg-neutral-800/50 px-3.5 rounded-full hover:bg-neutral-600/50" on:click={triggerPermissionRequest}>Enable</button>
     </div>
 {/if}

--- a/src/lib/components/Notifier.svelte
+++ b/src/lib/components/Notifier.svelte
@@ -8,10 +8,8 @@
     async function triggerPermissionRequest() {
         if (notificationSupported) {
             try {
-                if (Notification.permission === 'default') {
-                    permissionGranted = await Notification.requestPermission() === 'granted' ? true : false
-                    showNotice = false
-                }
+                permissionGranted = await Notification.requestPermission() === 'granted' ? true : false
+                showNotice = false
                 console.log(permissionGranted)
             } catch (e) {
                 showNotice = false

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -117,6 +117,12 @@
 		}, 1);
 	};
 
+	const standardiseTime = (rawTimerLength: string) => {
+		const timerLengthSeconds = inputParser(rawTimerLength)
+    	const formattedTimerLength = formatTime(timerLengthSeconds)
+		return formattedTimerLength
+	}
+
 	let interval: NodeJS.Timer;
 
 	const start = () => {
@@ -124,7 +130,7 @@
 			seconds -= 1;
 			if (seconds === 0) {
 				clearInterval(interval);
-				timerEndNotification(input) // show a notification on end
+				timerEndNotification(standardiseTime(input)) // show a notification on end
 			}
 		}, 1000);
 	};

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -22,6 +22,7 @@
 
 	import Customize from '$lib/components/Customize.svelte';
 	import Help from '$lib/components/Help.svelte';
+	import Notifier, { timerEndNotification } from '$lib/components/Notifier.svelte';
 
 	let input: string;
 	let seconds: number = null;
@@ -123,6 +124,7 @@
 			seconds -= 1;
 			if (seconds === 0) {
 				clearInterval(interval);
+				timerEndNotification(input) // show a notification on end
 			}
 		}, 1000);
 	};
@@ -154,11 +156,15 @@
 	};
 
 	const toggleTimer = () => {
-		toggle_count += 1;
-		if (toggle_count % 2 === 1) {
-			start();
+		if (seconds !== 0) {
+			toggle_count += 1;
+			if (toggle_count % 2 === 1) {
+				start();
+			} else {
+				stop();
+			}
 		} else {
-			stop();
+			reset() // "resuming" the timer when seconds is 0 will go to input mode
 		}
 	};
 
@@ -216,7 +222,8 @@
 		{/if}
 	</div>
 </div>
-<div class="min-h-screen flex place-items-center place-content-center px-4 md:px-8">
+<div class="min-h-screen flex place-items-center flex-col place-content-center px-4 md:px-8">
+	<Notifier/>
 	{#if current_block === 'help'}
 		<Help />
 	{:else if current_block === 'customize'}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -197,6 +197,7 @@
 <svelte:window on:keydown={handleKeydown} />
 <div class="absolute top-0 w-full flex p-4 sm:px-8 place-content-between place-items-center z-50">
 	<p class="text-lg font-medium" style:color={$colors.logo}>niagara</p>
+	<Notifier/>
 	<div class="flex gap-2 text-sm">
 		{#if !current_block}
 			<button class="hover:underline" on:click={reset}>reset</button>
@@ -223,7 +224,6 @@
 	</div>
 </div>
 <div class="min-h-screen flex place-items-center flex-col place-content-center px-4 md:px-8">
-	<Notifier/>
 	{#if current_block === 'help'}
 		<Help />
 	{:else if current_block === 'customize'}


### PR DESCRIPTION
I added notification functionality to the site. 
it first prompts the user if it wants notifications, (only once because browser remembers if yes or not)
and then it tries to send a notification once the timer goes off.
  
this pr consists of 2 parts:
## 1. the Notifier component
this shows this small thing **only when** the user is presented with the 'allow notifications' dialog:
![image](https://user-images.githubusercontent.com/21956756/185176550-3bd3a190-e0e1-446c-9e36-e86214420d53.png)  
this component then also exports a small helper function to actually send the notification using system Notification API.   
(feel free to check if it's correct to put it in a script context="module" but that's what i found in svelte docs)
## 2. a small bugfix
previously if you had the time at 00:00:00 (seconds = 0) and clicked the timer, it would start counting into negative.  
i added a small check for seconds === 0 and it resets the timer instead (goes into edit mode) when the seconds are 0 and it is clicked.

feel free to review the code before merging.
